### PR TITLE
getTodos.test.jsのリファクタリング

### DIFF
--- a/test/app/api/todos/getTodos.test.js
+++ b/test/app/api/todos/getTodos.test.js
@@ -1,24 +1,24 @@
-const request = require('supertest');
-const assert = require('power-assert');
-const app = require('../../../../app');
+const request = require("supertest");
+const assert = require("power-assert");
+const requestHelper = require("../../../../helper/requestHelper");
+const app = require("../../../../app");
 
-describe('test 「GET/api/todos」', () => {
-    it('totosリストがjson形式としてresponse.bodyで返ってきている', async() => {
-        const response = await request(app)
-            .get('/api/todos')
-            .set('Accept', 'application/json')
-            .expect('Content-Type', /json/)
-            .expect(200);
+describe("test 「GET/api/todos」", () => {
+  it("totosリストがjson形式としてresponse.bodyで返ってきている", async () => {
+    const response = await requestHelper.request({
+      method: "get",
+      endPoint: "/api/todos",
+      statusCode: 200
+    });
 
-        const todos = response.body;
-        assert.equal(Array.isArray(todos), true);
-        todos.forEach(todos => {
-            assert.equal(typeof todos.id, "number");
-            assert.equal(typeof todos.title, "string");
-            assert.equal(typeof todos.body, "string");
-            assert.equal(typeof todos.createdAt, "string");
-            assert.equal(typeof todos.updatedAt, "string");
-        })
-            
-    })
-})
+    const todos = response.body;
+    assert.equal(Array.isArray(todos), true);
+    todos.forEach(todos => {
+      assert.equal(typeof todos.id, "number");
+      assert.equal(typeof todos.title, "string");
+      assert.equal(typeof todos.body, "string");
+      assert.equal(typeof todos.createdAt, "string");
+      assert.equal(typeof todos.updatedAt, "string");
+    });
+  });
+});


### PR DESCRIPTION
##getTodos.test.js

`supertest`を使った素描のテストコードを、`requestHelper`に変更することでコード数の削減、リファクタリングを行なった。